### PR TITLE
🐛  Fix: scrapy-sentry-errors misconfiguration

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,8 +23,7 @@ env:
   AZURE_CONTAINER: ${{ secrets.AZURE_CONTAINER }}
   # GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
   # GCS_BUCKET = os.getenv("GCS_BUCKET")
-  # Setup Sentry, add the DSN to secrets and uncomment here
-  # SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
 
 jobs:

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -31,7 +31,7 @@ EXTENSIONS = {
     "city_scrapers_core.extensions.AzureBlobStatusExtension": 100,
     # "city_scrapers_core.extensions.S3StatusExtension": 100,
     # "city_scrapers_core.extensions.GCSStatusExtension": 100,
-    "scrapy_sentry.extensions.Errors": 10,
+    "scrapy_sentry_errors.extensions.Errors": 10,
     "scrapy.extensions.closespider.CloseSpider": None,
 }
 


### PR DESCRIPTION
## What's this PR do?

Fixes a misconfiguration issue with the `scrapy-sentry-errors` package that was introduced in #13 as a replacement to `scrapy-sentry`.

## Why are we doing this? 

The current misconfiguration is causing our spiders to fail. They're failing silently due to the way our deploy script works so the issue was only caught now.

## Steps to manually test

Trigger the "cron" workflow from the Github Action tab and select the `fix-sentry` branch rather than `main`. If the workflow completes successfully, the changes have been successful.

## Are there any smells or added technical debt to note? 
- Not tech debt, but just a note that this PR included adding `SENTRY_DSN` to the secrets for this repo's github actions.
- I triggered this manually and looked at [the output](https://github.com/City-Bureau/city-scrapers-philly/actions/runs/7786989372/job/21233068273) closely. It successfully ran our spiders