### PR TITLE
🕷️ Fix spider: Philadelphia Tax Review Board

### DIFF
--- a/tests/test_phipa_trb.py
+++ b/tests/test_phipa_trb.py
@@ -11,7 +11,7 @@ from city_scrapers.spiders.phipa_trb import PhipaTrbSpider
 
 test_response = file_response(
     join(dirname(__file__), "files", "phipa_trb.json"),
-    url="https://go.boarddocs.com/in/indps/Board.nsf/XML-ActiveMeetings",
+    url="https://calendar.google.com/calendar/u/0/embed?src=taxreviewboard@gmail.com",
 )
 spider = PhipaTrbSpider()
 
@@ -24,7 +24,7 @@ freezer.stop()
 
 
 def test_count():
-    assert len(parsed_items) == 62  # Adjusted based on provided data
+    assert len(parsed_items) == 62
 
 
 def test_title():


### PR DESCRIPTION
## What's this PR do?

A tweak to the testing suite for Philadelphia Tax Review Board spider (aka. `phipa_trb`). The mock response had the wrong URL.

## Why are we doing this?

Clean and tidy code. The URL was confusing.

## Steps to manually test

After installing the project using `pipenv`:

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl phipa_trb -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note?
