### PR TITLE
Update `actions/cache` to `v4`

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "7 11 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - bug/fix-cache-action-deprecated-v1
 
 env:
   CI: true

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "7 11 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - bug/fix-cache-action-deprecated-v1
 
 env:
   CI: true
@@ -28,7 +31,7 @@ jobs:
         uses: dschep/install-pipenv-action@v1
 
       - name: Cache Python dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pip-3.11-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: dschep/install-pipenv-action@v1
 
       - name: Cache Python dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "27 6 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - bug/fix-cache-action-deprecated-v1
 
 env:
   CI: true
@@ -35,7 +38,7 @@ jobs:
         uses: dschep/install-pipenv-action@v1
 
       - name: Cache Python dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pip-3.11-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "27 6 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - bug/fix-cache-action-deprecated-v1
 
 env:
   CI: true


### PR DESCRIPTION
## What's this PR do?
- Update `actions/cache` to `v4`.

## Why are we doing this?
- The current version `v1` is deprecated so it makes the job failed.
![Screenshot 2025-03-07 at 16 08 42](https://github.com/user-attachments/assets/dc79eac1-e767-453d-b3b3-61259385ee75)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the caching mechanism used in automated processes to enhance dependency management. This improvement contributes to smoother and more reliable background operations without altering visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->